### PR TITLE
Fix Compilation Issues on Linux with g++

### DIFF
--- a/src/SPCSampDir.h
+++ b/src/SPCSampDir.h
@@ -3,6 +3,7 @@
 #define SPCSAMPDIR_H_INCLUDED
 
 #include <stdint.h>
+#include <cstddef>
 
 #include <vector>
 

--- a/src/cpath.h
+++ b/src/cpath.h
@@ -61,7 +61,7 @@ static INLINE const char *path_findbase(const char *path)
 #ifdef _WIN32
 	return PathFindFileNameA(path);
 #else
-	char *pslash;
+	const char *pslash;
 
 	if (path == NULL)
 	{
@@ -85,8 +85,8 @@ static INLINE const char *path_findext(const char *path)
 #ifdef _WIN32
 	return PathFindExtensionA(path);
 #else
-	char *pdot;
-	char *pslash;
+	const char *pdot;
+	const char *pslash;
 
 	if (path == NULL)
 	{


### PR DESCRIPTION
Two minor issues preventing compilation on my linux machine.

First, a couple of strings needed to be tagged as const. Second, for some reason size_t wasn't being defined in one of the header files. 

g++ --version:

g++ (Gentoo 4.9.3 p1.2, pie-0.6.3) 4.9.3